### PR TITLE
fix: sanitize decoded path

### DIFF
--- a/src/util/RedirectHelper.ts
+++ b/src/util/RedirectHelper.ts
@@ -4,6 +4,7 @@ import {
   getHost,
   getPath,
   getProtocol,
+  getSanitizedPath,
   getSearch,
   HTTP_PROTOCOL,
   isValidUrl,
@@ -148,7 +149,7 @@ export class RedirectHelper {
       ...pathMatchResult,
       ...queryMatchResult,
     });
-    return new URL(destPath, this.destination).href;
+    return new URL(getSanitizedPath(destPath), this.destination).href;
   }
 
   private getPathMatchResult(url: URL): object | null {

--- a/src/util/Url.ts
+++ b/src/util/Url.ts
@@ -77,3 +77,9 @@ export function getPageExt(pagePath: string): string {
   const suffix = lastSubPath.split('.').pop() ?? '';
   return suffix.toLowerCase();
 }
+
+export function getSanitizedPath(path: string): string {
+  // After URL decoding: /[tab]/evil.com             => /evil.com
+  //                      /[newline]/[tab]/evil.com  => /evil.com
+  return path.replace(/^[/\t\n\r]+/, '/');
+}

--- a/test/util/RedirectHelper.test.ts
+++ b/test/util/RedirectHelper.test.ts
@@ -74,6 +74,25 @@ describe('test/util/RedirectHelper.test.ts', () => {
     assert.strictEqual(response!.href, 'https://www.exampleplus.com/1');
   });
 
+  it('should sanitize path regexp', () => {
+    const redirect = new RedirectHelper({
+      source: '/:path+/',
+      destination: 'https://www.example.com/:path+',
+      type: RedirectType.PATH_REGEXP,
+    });
+    let  response = redirect.redirect(new URL('https://www.example.com/%0a/evil.com/'));
+    assert.strictEqual(response!.status, 302);
+    assert.strictEqual(response!.href, 'https://www.example.com/evil.com');
+
+    response = redirect.redirect(new URL('https://www.example.com/%0a%09/evil.com/'));
+    assert.strictEqual(response!.status, 302);
+    assert.strictEqual(response!.href, 'https://www.example.com/evil.com');
+
+    response = redirect.redirect(new URL('https://www.example.com/%0a/%0d/evil.com/'));
+    assert.strictEqual(response!.status, 302);
+    assert.strictEqual(response!.href, 'https://www.example.com/evil.com');
+  });
+
   it('should param match work', () => {
     const redirect = new RedirectHelper({
       source: '/answer/detail?id=:id',


### PR DESCRIPTION
## Motivation

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve?-->

For now, with redirect rule in regexp like `/:path+/` to `https://example.com/:path+`, `/%0a/evil.com/` will be matched and transformed incorrectly to `https://evil.com`.
The reason is that the matched path was decoded, where `/%0a/evil.com` would become `//evil.com` which is considered to be a protocol-relative URL.

## Details

<!-- Explain how this pull request works -->

Just remove the heading characters composed by `/[/\t\n\r]/`.
